### PR TITLE
refactor(ast): reorganize AST module into subdirectory structure

### DIFF
--- a/parser/src/ast/expression/identifier.rs
+++ b/parser/src/ast/expression/identifier.rs
@@ -1,0 +1,39 @@
+//! Identifier expression node.
+//!
+//! Represents a variable or function name in the AST.
+
+use super::super::Node;
+use lexer::token::Token;
+
+/// An identifier (variable or function name) in the AST.
+///
+/// The `Identifier` structure holds both the token that produced
+/// the identifier (i.e., the original lexical representation)
+/// and the parsed name as a string. This allows the AST to retain
+/// precise information about where the identifier appeared in the source code,
+/// as well as provide convenient access to its value.
+///
+/// # Example
+/// Given code: `let myVar = 5;`
+/// The identifier `myVar` would be represented as:
+/// ```
+/// Identifier {
+///     token: Token { token_type: Ident, literal: "myVar".to_string() },
+///     value: "myVar".to_string(),
+/// }
+/// ```
+///
+/// Fields:
+/// - `token`: The token corresponding to the identifier (`Ident` token, with its literal).
+/// - `value`: The string name of the identifier, e.g., `"myVar"`.
+#[derive(Debug, Clone)]
+pub struct Identifier {
+    pub token: Token,  // The token corresponding to the identifier, e.g., Ident("myVar")
+    pub value: String, // The identifier's name as a string, e.g., "myVar"
+}
+
+impl Node for Identifier {
+    fn token_literal(&self) -> &str {
+        &self.token.literal
+    }
+}

--- a/parser/src/ast/expression/mod.rs
+++ b/parser/src/ast/expression/mod.rs
@@ -1,0 +1,25 @@
+//! Expression types in the Monkey language AST.
+//!
+//! Expressions represent values and computations that evaluate to a value.
+//! Each variant wraps a specific expression type.
+
+use super::Node;
+
+pub mod identifier;
+
+// Re-export for convenience
+pub use identifier::Identifier;
+
+/// Enum representing all expression types in the AST.
+#[derive(Debug, Clone)]
+pub enum Expression {
+    Identifier(identifier::Identifier),
+}
+
+impl Node for Expression {
+    fn token_literal(&self) -> &str {
+        match self {
+            Expression::Identifier(ident) => ident.token_literal(),
+        }
+    }
+}

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -7,40 +7,16 @@
 //! trait objects and to render nodes for debugging and tests.
 //! Contributors should extend these definitions when adding new language forms.
 
-use lexer::token::Token;
+use crate::ast::statement::Statement;
+pub mod expression;
+pub mod statement;
 
 pub trait Node {
+    /// Returns the literal string representation of the token that
+    /// this node represents.
     fn token_literal(&self) -> &str;
 }
-
-/// Enum representing all statement types in the AST.
-#[derive(Debug, Clone)]
-pub enum Statement {
-    Let(LetStatement),
-}
-
-/// Enum representing all expression types in the AST.
-#[derive(Debug, Clone)]
-pub enum Expression {
-    Identifier(Identifier),
-}
-
-impl Node for Statement {
-    fn token_literal(&self) -> &str {
-        match self {
-            Statement::Let(stmt) => stmt.token_literal(),
-        }
-    }
-}
-
-impl Node for Expression {
-    fn token_literal(&self) -> &str {
-        match self {
-            Expression::Identifier(ident) => ident.token_literal(),
-        }
-    }
-}
-
+/// The root node of the AST, containing all top-level statements.
 pub struct Program {
     pub statements: Vec<Statement>,
 }
@@ -52,30 +28,5 @@ impl Node for Program {
         } else {
             ""
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Identifier {
-    pub token: Token,
-    pub value: String,
-}
-
-impl Node for Identifier {
-    fn token_literal(&self) -> &str {
-        &self.token.literal
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct LetStatement {
-    pub token: Token,
-    pub name: Identifier,
-    pub value: Option<Expression>,
-}
-
-impl Node for LetStatement {
-    fn token_literal(&self) -> &str {
-        &self.token.literal
     }
 }

--- a/parser/src/ast/statement/let_statement.rs
+++ b/parser/src/ast/statement/let_statement.rs
@@ -1,0 +1,41 @@
+//! Let statement node.
+//!
+//! Represents a variable declaration: `let <identifier> = <expression>;`
+
+use crate::ast::expression::identifier::Identifier;
+use crate::ast::expression::Expression;
+use crate::ast::Node;
+use lexer::token::Token;
+
+/// Represents a `let` statement in the Monkey language AST.
+///
+/// A `let` statement binds an identifier to a value (expression).
+/// The structure preserves the original token, the identifier being declared,
+/// and the right-hand side expression (if present) assigned to it.
+///
+/// # Example
+/// For source code:
+/// ```monkey
+/// let myVar = 5;
+/// ```
+/// The node would contain:
+/// - `token`: The `let` token
+/// - `name`: Identifier node for `myVar`
+/// - `value`: Expression representing `5`
+///
+/// # Fields
+/// - `token`: Token corresponding to the `let` keyword
+/// - `name`: The identifier being declared
+/// - `value`: The expression assigned to the identifier (optional; may be `None` during parsing)
+#[derive(Debug, Clone)]
+pub struct LetStatement {
+    pub token: Token,
+    pub name: Identifier,
+    pub value: Option<Expression>,
+}
+
+impl Node for LetStatement {
+    fn token_literal(&self) -> &str {
+        &self.token.literal
+    }
+}

--- a/parser/src/ast/statement/mod.rs
+++ b/parser/src/ast/statement/mod.rs
@@ -1,0 +1,25 @@
+//! Statement types in the Monkey language AST.
+//!
+//! Statements represent actions or declarations in the program.
+//! Each variant wraps a specific statement type.
+
+use super::Node;
+
+pub mod let_statement;
+
+// Re-export for convenience
+pub use let_statement::LetStatement;
+
+/// Enum representing all statement types in the AST.
+#[derive(Debug, Clone)]
+pub enum Statement {
+    Let(let_statement::LetStatement),
+}
+
+impl Node for Statement {
+    fn token_literal(&self) -> &str {
+        match self {
+            Statement::Let(stmt) => stmt.token_literal(),
+        }
+    }
+}

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -10,9 +10,9 @@
 //! - Reports user-friendly errors via the `errors` vector.
 //! - Currently supports parsing `let` statements and collects them in `Program`.
 
-use crate::ast::Identifier;
-use crate::ast::LetStatement;
-use crate::ast::Statement;
+use crate::ast::expression::Identifier;
+use crate::ast::statement::LetStatement;
+use crate::ast::statement::Statement;
 use lexer::token::Token;
 use lexer::token::TokenType;
 use lexer::Lexer;


### PR DESCRIPTION
--ai

Reorganize the AST module from a single mod.rs file into a hierarchical subdirectory structure to improve maintainability and extensibility.

Changes:
- Move Node trait and Program struct into ast/mod.rs
- Extract Statement enum and LetStatement into ast/statement/ subdirectory
- Extract Expression enum and Identifier into ast/expression/ subdirectory
- Update import paths in lib.rs to use new module structure

This structure makes it easier to add new statement and expression types by creating new files in their respective subdirectories, reducing merge conflicts and improving code organization.

Structure:
- ast/mod.rs: Node trait, Program struct
- ast/statement/: Statement enum, LetStatement
- ast/expression/: Expression enum, Identifier